### PR TITLE
0.0.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Change the value of programs.selected.BSH_Common_Root_SelectedProgram leads to s
 
 ## Changelog
 
+### 0.0.32 (29.12.2020)
+
+- (Morluktom) bugfix for devices that are completely switched off (e.g. washing machine, dryer)
+
 ### 0.0.31
 
 - (ta2k) fix pause start command

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,11 @@
 {
     "common": {
         "name": "homeconnect",
-        "version": "0.0.31",
+        "version": "0.0.32",
         "news": {
+            "0.0.32": {
+                "en": "bugfix for devices that are completely switched off (e.g. washing machine, dryer)"
+            },   
             "0.0.31": {
                 "en": "fix pause start command bug"
             },     

--- a/main.js
+++ b/main.js
@@ -273,6 +273,26 @@ function startAdapter(options) {
             }
             if (stream.type == "CONNECTED") {
                 adapter.setState(lastEventId + ".general.connected", true, true);
+				const tokenID = adapter.namespace + ".dev.token";
+                stateGet(tokenID)
+                    .then(
+                        (value) => {
+                            const token = value;
+							getAPIValues(token, lastEventId, "/status");
+							getAPIValues(token, lastEventId, "/settings");
+							getAPIValues(token, lastEventId, "/programs");
+							getAPIValues(token, lastEventId, "/programs/active");
+							getAPIValues(token, lastEventId, "/programs/selected");
+							updateOptions(token, lastEventId, "/programs/active");
+							updateOptions(token, lastEventId, "/programs/selected");
+                        },
+                        (err) => {
+                            adapter.log.error("FEHLER: " + err);
+                        }
+                    )
+                    .catch(() => {
+                        adapter.log.debug("No token found");
+                    });							
                 return;
             }
 
@@ -653,11 +673,11 @@ function startAdapter(options) {
                 native: {},
             });
             const tokenID = adapter.namespace + ".dev.token";
-            if (element.connected) {
-                stateGet(tokenID)
-                    .then(
-                        (value) => {
-                            const token = value;
+            stateGet(tokenID)
+                .then(
+                    (value) => {
+                        const token = value;
+                        if (element.connected) {
                             getAPIValues(token, haId, "/status");
                             getAPIValues(token, haId, "/settings");
                             getAPIValues(token, haId, "/programs");
@@ -665,18 +685,16 @@ function startAdapter(options) {
                             getAPIValues(token, haId, "/programs/selected");
                             updateOptions(token, haId, "/programs/active");
                             updateOptions(token, haId, "/programs/selected");
-                            startEventStream(token, haId);
-                        },
-                        (err) => {
-                            adapter.log.error("FEHLER: " + err);
                         }
-                    )
-                    .catch(() => {
-                        adapter.log.debug("No token found");
-                    });
-            } else {
-                adapter.log.warn(haId + " is not connected cannot fetch information.");
-            }
+                        startEventStream(token, haId);
+                    },
+                    (err) => {
+                        adapter.log.error("FEHLER: " + err);
+                    }
+                )
+                .catch(() => {
+                    adapter.log.debug("No token found");
+                });
         });
         //Delete old states
         adapter.getStates("*", (err, states) => {

--- a/package.json
+++ b/package.json
@@ -65,5 +65,5 @@
     "test:package": "mocha test/package --exit",
     "test:unit": "mocha test/unit --exit"
   },
-  "version": "0.0.31"
+  "version": "0.0.32"
 }


### PR DESCRIPTION
In all devices that were completely switched off when the adapter was restarted, the adapter did not work as soon as they were switched on.
My change, even if a device is switched off, the EventStream is started, and as soon as the connected event comes, the data points are only updated.