### PR TITLE
assure re-login for invalid refresh tokens

### DIFF
--- a/main.js
+++ b/main.js
@@ -840,9 +840,11 @@ class Homeconnect extends utils.Adapter {
                 this.log.error(error);
                 error.response && this.log.error(JSON.stringify(error.response.data));
                 this.log.error("Start relogin in 10min");
+                this.reconnectTimeout && clearInterval(this.reconnectTimeout)
                 this.reLoginTimeout && clearTimeout(this.reLoginTimeout);
-                this.reLoginTimeout = setTimeout(() => {
-                    this.login();
+                this.reLoginTimeout = setTimeout(async () => {
+                    await this.login();
+                    this.startEventStream()
                 }, 1000 * 60 * 10);
             });
     }


### PR DESCRIPTION
This code fixes a loop that can happen when a refresh token is no longer valid. 
The re-login should generate a new refresh token but it's never actually called. The KEEP-ALIVE listener triggers a reconnect of the eventsource before the login happens, which resets the login timeout.
 
This fix makes sure that the login is done before attempting to reconnect again.